### PR TITLE
Fix frontend Docker health check failing on Alpine

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+*.md
+.env*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,9 +33,10 @@ COPY --from=builder /app/dist ./dist
 # Expose port
 EXPOSE 3000
 
-# Health check
-HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:3000/ || exit 1
+# Health check - use node's built-in fetch (available in Node 20+)
+# BusyBox wget on Alpine doesn't support --tries flag
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "fetch('http://localhost:3000/').then(r=>{if(!r.ok)throw r;process.exit(0)}).catch(()=>process.exit(1))"
 
 # Serve static files - SPA fallback to /index.html
 CMD ["http-server", "dist", "-p", "3000", "-g"]


### PR DESCRIPTION
BusyBox wget on node:20-alpine doesn't support the --tries flag
(GNU wget only), causing the health check to always fail with an
unrecognized option error and marking the container unhealthy.

Replace wget-based health check with Node.js built-in fetch() and
increase start period to 10s. Also add .dockerignore to exclude
node_modules from the build context.

https://claude.ai/code/session_012gyohsvMdJHAmDbfKnEoQU